### PR TITLE
Añadir Firestore a Koin.

### DIFF
--- a/app/src/main/java/edu/iesam/diarybook/app/DiaryBookApplication.kt
+++ b/app/src/main/java/edu/iesam/diarybook/app/DiaryBookApplication.kt
@@ -2,7 +2,8 @@ package edu.iesam.diarybook.app
 
 import android.app.Application
 import com.google.firebase.FirebaseApp
-import edu.iesam.diarybook.app.di.AppModule
+import edu.iesam.diarybook.app.di.LocalModule
+import edu.iesam.diarybook.app.di.RemoteModule
 import edu.iesam.diarybook.di.event.EventModule
 import edu.iesam.diarybook.di.task.TaskModule
 import org.koin.android.ext.koin.androidContext
@@ -18,7 +19,8 @@ class DiaryBookApplication : Application() {
         startKoin {
             androidContext(this@DiaryBookApplication)
             modules(
-                AppModule().module,
+                LocalModule().module,
+                RemoteModule().module,
                 EventModule().module,
                 TaskModule().module
             )

--- a/app/src/main/java/edu/iesam/diarybook/app/di/LocalModule.kt
+++ b/app/src/main/java/edu/iesam/diarybook/app/di/LocalModule.kt
@@ -11,7 +11,7 @@ const val TIME_CACHE = 60 * 1000
 
 @Module
 @ComponentScan("edu.iesam.diarybook")
-class AppModule {
+class LocalModule {
 
     @Single
     fun provideDataBase(context: Context): AppDataBase {

--- a/app/src/main/java/edu/iesam/diarybook/app/di/RemoteModule.kt
+++ b/app/src/main/java/edu/iesam/diarybook/app/di/RemoteModule.kt
@@ -1,0 +1,16 @@
+package edu.iesam.diarybook.app.di
+
+import com.google.firebase.firestore.FirebaseFirestore
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
+
+@Module
+@ComponentScan("edu.iesam.diarybook")
+class RemoteModule {
+
+    @Single
+    fun provideFirebase(): FirebaseFirestore {
+        return FirebaseFirestore.getInstance()
+    }
+}

--- a/app/src/main/java/edu/iesam/diarybook/data/event/remote/EventFirebaseRemoteDataSource.kt
+++ b/app/src/main/java/edu/iesam/diarybook/data/event/remote/EventFirebaseRemoteDataSource.kt
@@ -1,18 +1,15 @@
 package edu.iesam.diarybook.data.event.remote
 
-import com.google.firebase.Firebase
-import com.google.firebase.firestore.firestore
+import com.google.firebase.firestore.FirebaseFirestore
 import edu.iesam.diarybook.domain.event.Event
 import kotlinx.coroutines.tasks.await
 import org.koin.core.annotation.Single
 
 @Single
-class EventFirebaseRemoteDataSource {
-
-    private val db = Firebase.firestore
+class EventFirebaseRemoteDataSource(private val firestore: FirebaseFirestore) {
 
     suspend fun getEventList(): List<Event> {
-        val events = db.collection("events")
+        val events = firestore.collection("events")
             .get()
             .await()
             .map {

--- a/app/src/main/java/edu/iesam/diarybook/data/task/remote/TaskFirebaseRemoteDataSource.kt
+++ b/app/src/main/java/edu/iesam/diarybook/data/task/remote/TaskFirebaseRemoteDataSource.kt
@@ -1,18 +1,15 @@
 package edu.iesam.diarybook.data.task.remote
 
-import com.google.firebase.Firebase
-import com.google.firebase.firestore.firestore
+import com.google.firebase.firestore.FirebaseFirestore
 import edu.iesam.diarybook.domain.task.Task
 import kotlinx.coroutines.tasks.await
 import org.koin.core.annotation.Single
 
 @Single
-class TaskFirebaseRemoteDataSource {
-
-    private val db = Firebase.firestore
+class TaskFirebaseRemoteDataSource(private val firestore: FirebaseFirestore) {
 
     suspend fun getTaskList(): List<Task> {
-        val tasks = db.collection("tasks")
+        val tasks = firestore.collection("tasks")
             .get()
             .await()
             .map {


### PR DESCRIPTION
## 🤔 Descripción del problema a resolver

Se pide implementar Firestore en un módulo de Koin.

## 💡 Proceso seguido para resolver el problema.

Se inicializa Firestore en RemoteModule, este es el módulo encargado de las inicializaciones de herramientas para la parte de remoto, se implanta esta mejora para no inicializar Firestore más de una vez.

## 👩‍💻 Resumen de los cambios introducidos

Se inicializa Firestore, se modifican nombres de módulos para una mejor estructura y se pasa Firestore por constructor a las clases que manejan el control de los datos de eventos y tareas.

## 📸 Screenshot o Video

<img src="https://github.com/user-attachments/assets/ab152144-16f7-478b-a7dc-29b9d29d54aa" width="300">